### PR TITLE
Fix typo in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 # 備註!!!
 
-## anroid app 重要檔案索引位置
+## Android app 重要檔案索引位置
 1. [AndroidManifest.xml](app/src/main/AndroidManifest.xml):
     用來設定使用到的ui及他的java檔
     設定API keys


### PR DESCRIPTION
## Summary
- fix header in README from `anroid` to `Android`

## Testing
- `grep -n "Android app" README.md`

------
https://chatgpt.com/codex/tasks/task_e_685465a8e338832bb0f3d77445b69d91