### PR TITLE
Fix duplicate maps dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation 'com.google.android.gms:play-services-maps:18.0.1'
     implementation 'com.google.android.gms:play-services-location:18.0.0'
 
 }


### PR DESCRIPTION
## Summary
- remove duplicate `play-services-maps` dependency

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685466527ba4832bb2f4b9fa0f2d5301